### PR TITLE
Fixed entrypoint script not working in the scratch image since there is no sh binary in an empty image scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,14 @@ RUN mkdir /user && \
 FROM scratch as scratch
 COPY --from=builder /go/src/github.com/prometheus/memcached_exporter/memcached_exporter /bin/memcached_exporter
 COPY --from=builder /user/group /user/passwd /etc/
-COPY ./entrypoint.sh ./entrypoint.sh
 
 EXPOSE      9150
 USER        nobody
-ENTRYPOINT  [ "./entrypoint.sh" ]
+ENTRYPOINT  [ "/bin/memcached_exporter" ]
 
 FROM quay.io/sysdig/sysdig-mini-ubi:1.4.11 as ubi
 COPY --from=builder /go/src/github.com/prometheus/memcached_exporter/memcached_exporter /bin/memcached_exporter
-COPY ./entrypoint.sh ./entrypoint.sh
 
-USER       nobody
-ENTRYPOINT ["./entrypoint.sh"]
-EXPOSE     9150
+EXPOSE      9150
+USER        nobody
+ENTRYPOINT  [ "/bin/memcached_exporter" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-if [ -z ${MEMCACHED_ADDR} ]; then
-    /bin/memcached_exporter
-else
-    /bin/memcached_exporter --memcached.address=MEMCACHED_ADDR:11211
-fi


### PR DESCRIPTION
The arguments like the '-memcached.address' or any other argument can be passed as args in Kubernetes